### PR TITLE
fix: unify frontend and backend supported file type contract

### DIFF
--- a/frontend/src/components/PiiSentinelUI.js
+++ b/frontend/src/components/PiiSentinelUI.js
@@ -2,12 +2,12 @@ import React, { useState } from "react";
 import { Card, CardContent } from "../components/card";
 import { Button } from "../components/button";
 import { Input } from "../components/input";
-import { SUPPORTED_EXTENSIONS } from "../utils/constants";
+import { FALLBACK_SUPPORTED_EXTENSIONS } from "../utils/fileTypes";
 import { authFetch } from "../utils/authFetch";
 import { getResponseMessage, readResponseData } from "../utils/http";
 import { downloadProtectedAsset, getDownloadErrorMessage } from "../utils/downloads";
 
-export default function PiiSentinelUI() {
+export default function PiiSentinelUI({ allowedTypes = FALLBACK_SUPPORTED_EXTENSIONS }) {
   const [file, setFile] = useState(null);
   const [piiColumns, setPiiColumns] = useState([]);
   const [riskScore, setRiskScore] = useState(null);
@@ -123,7 +123,7 @@ export default function PiiSentinelUI() {
             <Input
               id="file-upload"
               type="file"
-              accept={SUPPORTED_EXTENSIONS.join(",")}
+              accept={allowedTypes.join(",")}
               required
               onChange={handleFileChange}
             />

--- a/frontend/src/pages/Upload.js
+++ b/frontend/src/pages/Upload.js
@@ -1,10 +1,30 @@
 import React from "react";
 import PiiSentinelUI from "../components/PiiSentinelUI";
 
-import { SUPPORTED_EXTENSIONS } from "../utils/constants";
+import { FALLBACK_SUPPORTED_EXTENSIONS, fetchSupportedFileTypes } from "../utils/fileTypes";
 
 function Upload() {
-  const [supportedFileTypes] = React.useState(SUPPORTED_EXTENSIONS);
+  const [supportedFileTypes, setSupportedFileTypes] = React.useState(FALLBACK_SUPPORTED_EXTENSIONS);
+
+  React.useEffect(() => {
+    let active = true;
+
+    fetchSupportedFileTypes()
+      .then((extensions) => {
+        if (active) {
+          setSupportedFileTypes(extensions);
+        }
+      })
+      .catch(() => {
+        if (active) {
+          setSupportedFileTypes(FALLBACK_SUPPORTED_EXTENSIONS);
+        }
+      });
+
+    return () => {
+      active = false;
+    };
+  }, []);
 
   return (
     <div className="page-shell flex flex-col items-center justify-center gap-4 py-12">
@@ -16,7 +36,7 @@ function Upload() {
         {supportedFileTypes.join(",")}
       </p>
 
-      <PiiSentinelUI allowedTypes={SUPPORTED_EXTENSIONS} />
+      <PiiSentinelUI allowedTypes={supportedFileTypes} />
     </div>
   );
 }

--- a/frontend/src/pages/Upload.test.js
+++ b/frontend/src/pages/Upload.test.js
@@ -1,0 +1,48 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import Upload from "./Upload";
+
+jest.mock("../components/PiiSentinelUI", () => jest.fn(({ allowedTypes }) => (
+  <div data-testid="pii-ui">{allowedTypes.join(",")}</div>
+)));
+
+jest.mock("../utils/fileTypes", () => ({
+  FALLBACK_SUPPORTED_EXTENSIONS: [".csv", ".xls"],
+  fetchSupportedFileTypes: jest.fn(),
+}));
+
+const PiiSentinelUI = require("../components/PiiSentinelUI");
+const { fetchSupportedFileTypes } = require("../utils/fileTypes");
+
+describe("Upload", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("renders backend-supported file types including .xls", async () => {
+    fetchSupportedFileTypes.mockResolvedValue([".csv", ".xls", ".xlsx"]);
+
+    render(<Upload />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/\.csv,\.xls,\.xlsx/i)).toBeInTheDocument();
+    });
+    expect(PiiSentinelUI).toHaveBeenLastCalledWith(
+      expect.objectContaining({ allowedTypes: [".csv", ".xls", ".xlsx"] }),
+      expect.anything(),
+    );
+  });
+
+  test("falls back to local contract when backend types cannot be loaded", async () => {
+    fetchSupportedFileTypes.mockRejectedValue(new Error("network"));
+
+    render(<Upload />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/\.csv,\.xls/i)).toBeInTheDocument();
+    });
+    expect(PiiSentinelUI).toHaveBeenLastCalledWith(
+      expect.objectContaining({ allowedTypes: [".csv", ".xls"] }),
+      expect.anything(),
+    );
+  });
+});

--- a/frontend/src/utils/constants.js
+++ b/frontend/src/utils/constants.js
@@ -1,7 +1,6 @@
 // constants.js
 export const SUPPORTED_EXTENSIONS = [
   ".csv",
-  ".xlsx",
   ".tsv",
   ".txt",
   ".log",
@@ -10,11 +9,12 @@ export const SUPPORTED_EXTENSIONS = [
   ".docx",
   ".pdf",
   ".html",
+  ".xls",
+  ".xlsx",
 ];
 
 export const FILE_TYPE_LABELS = {
   ".csv": "CSV (Comma Separated)",
-  ".xlsx": "Excel Spreadsheet",
   ".tsv": "TSV (Tab Separated)",
   ".txt": "Text File",
   ".log": "Log File",
@@ -23,4 +23,6 @@ export const FILE_TYPE_LABELS = {
   ".docx": "Word Document",
   ".pdf": "PDF Document",
   ".html": "HTML Page",
+  ".xls": "Excel 97-2003 Spreadsheet",
+  ".xlsx": "Excel Spreadsheet",
 };

--- a/frontend/src/utils/fileTypes.js
+++ b/frontend/src/utils/fileTypes.js
@@ -1,0 +1,21 @@
+import { apiUrl } from "./api";
+import { SUPPORTED_EXTENSIONS as FALLBACK_SUPPORTED_EXTENSIONS } from "./constants";
+
+export async function fetchSupportedFileTypes() {
+  const response = await fetch(apiUrl("/scans/supported-file-types"), {
+    credentials: "include",
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to load supported file types: ${response.status}`);
+  }
+
+  const payload = await response.json();
+  const supportedExtensions = Array.isArray(payload?.supported_extensions)
+    ? payload.supported_extensions
+    : [];
+
+  return supportedExtensions.length > 0 ? supportedExtensions : FALLBACK_SUPPORTED_EXTENSIONS;
+}
+
+export { FALLBACK_SUPPORTED_EXTENSIONS };

--- a/routers/scans.py
+++ b/routers/scans.py
@@ -26,7 +26,7 @@ from services.retention_service import apply_retention_state, apply_retention_st
 from services.scan_service import ScanContext, ScanLimitError, run_scan_pipeline
 from services.security_service import extract_request_security_context, register_scan_activity
 from utils.api_errors import error_payload
-from utils.constants import SUPPORTED_EXTENSIONS
+from utils.constants import SUPPORTED_EXTENSIONS, SUPPORTED_EXTENSIONS_SORTED
 from utils.plan_features import get_plan_features
 from utils.rbac import ROLE_ORG_ADMIN, ROLE_SECURITY_ADMIN, has_any_role
 from utils.tier_limiter import release_scan_quota_reservation, reserve_scan_quota
@@ -523,6 +523,11 @@ async def create_scan(
     finally:
         if temp_path and os.path.exists(temp_path):
             os.remove(temp_path)
+
+
+@router.get("/supported-file-types")
+def get_supported_file_types():
+    return {"supported_extensions": SUPPORTED_EXTENSIONS_SORTED}
 
 
 @router.get("")

--- a/tests/test_scan_api_consolidation.py
+++ b/tests/test_scan_api_consolidation.py
@@ -18,6 +18,7 @@ from database.models.user import User
 from dependencies.tier_guard import get_current_user_context
 from routers import scans as scans_router
 from services.scan_service import ScanPipelineResult
+from utils.constants import SUPPORTED_EXTENSIONS_SORTED
 
 
 def _make_local_test_dir() -> Path:
@@ -200,3 +201,72 @@ def test_scan_download_and_report_routes_return_assets(monkeypatch):
     finally:
         shutil.rmtree(base, ignore_errors=True)
         session.close()
+
+
+def test_supported_file_types_endpoint_matches_backend_contract():
+    session_factory = _session()
+    app = _build_app(session_factory)
+    client = TestClient(app)
+
+    response = client.get("/scans/supported-file-types")
+
+    assert response.status_code == 200
+    assert response.json()["supported_extensions"] == SUPPORTED_EXTENSIONS_SORTED
+    assert ".xls" in response.json()["supported_extensions"]
+
+
+def test_post_scans_accepts_xls_when_backend_supports_it(monkeypatch):
+    base = _make_local_test_dir()
+    session_factory = _session()
+    app = _build_app(session_factory)
+    client = TestClient(app)
+
+    monkeypatch.chdir(base)
+    monkeypatch.setattr(scans_router, "record_audit_event", lambda *args, **kwargs: None)
+    monkeypatch.setattr(scans_router, "register_scan_activity", lambda *args, **kwargs: None)
+    monkeypatch.setattr(scans_router, "reserve_scan_quota", lambda *args, **kwargs: True)
+    monkeypatch.setattr(scans_router, "release_scan_quota_reservation", lambda *args, **kwargs: None)
+    monkeypatch.setattr(scans_router, "extract_request_security_context", lambda request: {})
+
+    async def _inline_run_in_threadpool(func):
+        return func()
+
+    monkeypatch.setattr(scans_router, "run_in_threadpool", _inline_run_in_threadpool)
+    monkeypatch.setattr(
+        scans_router,
+        "run_scan_pipeline",
+        lambda **kwargs: ScanPipelineResult(
+            filename="sheet.xls",
+            pii_columns=[],
+            redacted_file="redacted/redacted_sheet.xls",
+            risk_score=0,
+            redacted_count=0,
+            total_values=0,
+            redacted_type_counts={},
+            scan_id=88,
+        ),
+    )
+
+    try:
+        response = client.post(
+            "/scans",
+            files={"file": ("sheet.xls", b"\xD0\xCF\x11\xE0\xA1\xB1\x1A\xE1rest", "application/vnd.ms-excel")},
+        )
+        assert response.status_code == 200
+        assert response.json()["scan_id"] == 88
+    finally:
+        shutil.rmtree(base, ignore_errors=True)
+
+
+def test_post_scans_rejects_unsupported_file_type():
+    session_factory = _session()
+    app = _build_app(session_factory)
+    client = TestClient(app)
+
+    response = client.post(
+        "/scans",
+        files={"file": ("archive.exe", b"MZ", "application/octet-stream")},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"]["error_code"] == "unsupported_file_type"

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -1,4 +1,5 @@
 SUPPORTED_EXTENSIONS = {
     ".csv", ".tsv", ".txt", ".log", ".json", ".xml", ".docx", ".pdf", ".html",
-    ".xls", ".xlsx"  
+    ".xls", ".xlsx"
 }
+SUPPORTED_EXTENSIONS_SORTED = sorted(SUPPORTED_EXTENSIONS)


### PR DESCRIPTION
Frontend and backend had drifted on upload support: the backend accepted\n.xls while the frontend constants and upload UI did not expose it.\n\nThis change keeps backend validation canonical, adds a lightweight\n/supported-file-types contract endpoint, and updates the upload UI to\nconsume that contract with a local fallback so the frontend stays aligned\nwithout introducing a larger cross-language generation system.