### PR TITLE
feat: render individual tests separately with per-test run history

### DIFF
--- a/frontend/src/components/compliance/testing/TestCategoryRail.js
+++ b/frontend/src/components/compliance/testing/TestCategoryRail.js
@@ -37,6 +37,7 @@ export default function TestCategoryRail({ categories, selectedCategory, onSelec
               <StatPill label="Fail" value={item.failing} tone="bg-rose-500/10 text-rose-300" />
               <StatPill label="Flaky" value={item.flaky} tone="bg-cyan-500/10 text-cyan-200" />
               <StatPill label="Skip" value={item.skipped} tone="bg-amber-500/10 text-amber-200" />
+              <StatPill label="Not run" value={item.not_run || 0} tone="bg-amber-500/10 text-amber-100" />
             </div>
             <div className="mt-4 flex items-center justify-between text-xs text-app-muted">
               <span>{item.total_tests} tests</span>

--- a/frontend/src/components/compliance/testing/TestDetailPanel.js
+++ b/frontend/src/components/compliance/testing/TestDetailPanel.js
@@ -16,7 +16,8 @@ function HistoryItem({ item }) {
       <div className="flex items-start justify-between gap-3">
         <div>
           <p className="font-semibold text-app">{item.suite_name}</p>
-          <p className="mt-1 text-xs text-app-muted">{formatDateTime(item.last_run_timestamp)} · {item.environment}</p>
+          <p className="mt-1 text-xs text-app-muted">{formatDateTime(item.last_run_timestamp)} | {item.environment}</p>
+          <p className="mt-1 text-[11px] text-app-muted">{item.file_path || item.file_name || "No file path recorded"}</p>
         </div>
         <span className={`rounded-full px-3 py-1 text-xs font-semibold ${statusBadgeClass(item.status)}`}>{item.status}</span>
       </div>
@@ -42,13 +43,15 @@ export default function TestDetailPanel({ test }) {
         <div>
           <p className="text-xs font-semibold uppercase tracking-[0.2em] text-app-muted">Selected Test</p>
           <h2 className="mt-2 text-2xl font-semibold text-app">{test.test_name}</h2>
-          <p className="mt-2 text-sm text-app-secondary">{test.category} · {test.suite_name}</p>
+          <p className="mt-2 text-sm text-app-secondary">{test.category} | {test.suite_name}</p>
         </div>
         <span className={`rounded-full px-3 py-1 text-xs font-semibold ${statusBadgeClass(test.status)}`}>{test.status}</span>
       </div>
 
       <div className="mt-5 grid gap-3 sm:grid-cols-2">
         <DetailField label="Test ID">{test.test_id}</DetailField>
+        <DetailField label="Pytest Node ID">{test.test_node_id || "Not recorded"}</DetailField>
+        <DetailField label="File Path">{test.file_path || test.file_name || "Not recorded"}</DetailField>
         <DetailField label="Latest Environment">{test.latest_environment || "default"}</DetailField>
         <DetailField label="Pass Rate">{formatPercent(test.pass_rate)}</DetailField>
         <DetailField label="Flake Rate">{formatPercent((test.flake_rate || 0) * 100)}</DetailField>

--- a/frontend/src/components/compliance/testing/TestInventoryTable.js
+++ b/frontend/src/components/compliance/testing/TestInventoryTable.js
@@ -10,8 +10,8 @@ function FlakyIndicator({ flaky }) {
 export default function TestInventoryTable({ tests, selectedTestId, onSelectTest }) {
   return (
     <div className="surface-card overflow-hidden rounded-3xl">
-      <div className="grid gap-3 border-b border-app px-5 py-4 text-[11px] font-semibold uppercase tracking-[0.18em] text-app-muted md:grid-cols-[2.2fr_0.9fr_0.9fr_0.8fr_1fr_0.9fr_0.8fr]">
-        <div>Test Name</div>
+      <div className="grid gap-3 border-b border-app px-5 py-4 text-[11px] font-semibold uppercase tracking-[0.18em] text-app-muted md:grid-cols-[2.4fr_0.9fr_0.9fr_0.8fr_1fr_0.9fr_0.8fr]">
+        <div>Test Case</div>
         <div>Status</div>
         <div>Pass Rate</div>
         <div>Runs</div>
@@ -25,11 +25,12 @@ export default function TestInventoryTable({ tests, selectedTestId, onSelectTest
             key={test.test_id}
             type="button"
             onClick={() => onSelectTest(test)}
-            className={`grid w-full gap-3 border-t border-app px-5 py-4 text-left text-sm transition hover:bg-white/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300 md:grid-cols-[2.2fr_0.9fr_0.9fr_0.8fr_1fr_0.9fr_0.8fr] ${selectedTestId === test.test_id ? "bg-white/5" : ""}`}
+            className={`grid w-full gap-3 border-t border-app px-5 py-4 text-left text-sm transition hover:bg-white/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300 md:grid-cols-[2.4fr_0.9fr_0.9fr_0.8fr_1fr_0.9fr_0.8fr] ${selectedTestId === test.test_id ? "bg-white/5" : ""}`}
           >
             <div>
               <p className="font-semibold text-app">{test.test_name}</p>
-              <p className="mt-1 text-xs text-app-muted">{test.file_name || test.category}</p>
+              <p className="mt-1 text-xs text-app-muted">{test.file_path || test.file_name || test.category}</p>
+              <p className="mt-1 text-[11px] text-app-muted">{test.test_node_id}</p>
             </div>
             <div><span className={`rounded-full px-3 py-1 text-xs font-semibold ${statusBadgeClass(test.status)}`}>{test.status}</span></div>
             <div className="text-app-secondary">{formatPercent(test.pass_rate)}</div>

--- a/frontend/src/pages/compliance/ComplianceTestingPage.js
+++ b/frontend/src/pages/compliance/ComplianceTestingPage.js
@@ -30,6 +30,7 @@ export default function ComplianceTestingPage() {
   } = useCompliancePageContext();
   const [selectedCategory, setSelectedCategory] = useState(null);
   const [search, setSearch] = useState("");
+  const [filePathFilter, setFilePathFilter] = useState("");
   const [statusFilter, setStatusFilter] = useState("");
   const [sort, setSort] = useState("last_run");
   const [interactionError, setInteractionError] = useState(null);
@@ -55,6 +56,7 @@ export default function ComplianceTestingPage() {
         setInteractionError(null);
         await loadTestCategory(selectedCategory, {
           search: search.trim() || undefined,
+          file_path: filePathFilter.trim() || undefined,
           status: statusFilter || undefined,
           sort,
         });
@@ -69,7 +71,7 @@ export default function ComplianceTestingPage() {
     return () => {
       cancelled = true;
     };
-  }, [loadTestCategory, search, selectedCategory, sort, statusFilter]);
+  }, [filePathFilter, loadTestCategory, search, selectedCategory, sort, statusFilter]);
 
   const categorySummary = useMemo(() => {
     const summary = testCategoryDetail?.summary || {};
@@ -78,6 +80,7 @@ export default function ComplianceTestingPage() {
       passing: summary.passing ?? 0,
       failing: summary.failing ?? 0,
       skipped: summary.skipped ?? 0,
+      notRun: summary.not_run ?? 0,
       flaky: summary.flaky ?? 0,
       passRate: summary.average_pass_rate ?? summary.pass_rate ?? 0,
       lastRun: summary.last_run_timestamp ?? selectedCategoryMeta?.last_run_timestamp ?? null,
@@ -137,17 +140,27 @@ export default function ComplianceTestingPage() {
                   <div><p className="text-xs uppercase tracking-[0.18em] text-app-muted">Failing</p><p className="mt-1 text-lg font-semibold text-rose-300">{categorySummary.failing}</p></div>
                   <div><p className="text-xs uppercase tracking-[0.18em] text-app-muted">Skipped</p><p className="mt-1 text-lg font-semibold text-amber-200">{categorySummary.skipped}</p></div>
                   <div><p className="text-xs uppercase tracking-[0.18em] text-app-muted">Flaky</p><p className="mt-1 text-lg font-semibold text-cyan-200">{categorySummary.flaky}</p></div>
+                  <div><p className="text-xs uppercase tracking-[0.18em] text-app-muted">Not Run</p><p className="mt-1 text-lg font-semibold text-amber-200">{categorySummary.notRun}</p></div>
                   <div><p className="text-xs uppercase tracking-[0.18em] text-app-muted">Last Run</p><p className="mt-1 text-sm font-medium text-app-secondary">{formatDateTime(categorySummary.lastRun)}</p></div>
                 </div>
               </div>
 
-              <div className="mt-4 grid gap-3 lg:grid-cols-[1.5fr_1fr_1fr]">
+              <div className="mt-4 grid gap-3 lg:grid-cols-[1.2fr_1.1fr_1fr_1fr]">
                 <label className="flex flex-col gap-2 text-sm text-app-secondary">
                   <span>Search Tests</span>
                   <input
                     value={search}
                     onChange={(event) => setSearch(event.target.value)}
                     placeholder="Search by name, description, or file"
+                    className="rounded-2xl border border-app bg-app px-3 py-3 text-sm text-app focus-visible:outline-none"
+                  />
+                </label>
+                <label className="flex flex-col gap-2 text-sm text-app-secondary">
+                  <span>File Path</span>
+                  <input
+                    value={filePathFilter}
+                    onChange={(event) => setFilePathFilter(event.target.value)}
+                    placeholder="Filter by tests/path.py"
                     className="rounded-2xl border border-app bg-app px-3 py-3 text-sm text-app focus-visible:outline-none"
                   />
                 </label>
@@ -160,6 +173,7 @@ export default function ComplianceTestingPage() {
                     { value: "passed", label: "Passed" },
                     { value: "failed", label: "Failed" },
                     { value: "skipped", label: "Skipped" },
+                    { value: "not_run", label: "Not Run" },
                     { value: "flaky", label: "Flaky" },
                   ]}
                 />

--- a/frontend/src/pages/compliance/ComplianceTestingPage.test.js
+++ b/frontend/src/pages/compliance/ComplianceTestingPage.test.js
@@ -13,6 +13,7 @@ jest.mock("./useCompliancePageContext", () => ({
         passing_tests: 9,
         failing_tests: 2,
         flaky_tests: 1,
+        not_run_tests: 1,
         average_pass_rate: 87,
         total_executions_last_7_days: 34,
       },
@@ -24,40 +25,31 @@ jest.mock("./useCompliancePageContext", () => ({
           passing: 2,
           failing: 1,
           skipped: 0,
+          not_run: 0,
           flaky: 1,
           average_pass_rate: 76,
           status: "failed",
           last_run_timestamp: "2026-03-11T12:00:00+00:00",
-        },
-        {
-          category: "security tests",
-          description: "Authentication and hardening coverage.",
-          total_tests: 3,
-          passing: 3,
-          failing: 0,
-          skipped: 0,
-          flaky: 0,
-          average_pass_rate: 100,
-          status: "passed",
-          last_run_timestamp: "2026-03-10T12:00:00+00:00",
         },
       ],
     },
     testCategoryDetail: {
       category: "privacy tests",
       summary: {
-        total_tests: 2,
+        total_tests: 3,
         passing: 1,
         failing: 1,
         skipped: 0,
+        not_run: 1,
         flaky: 1,
         average_pass_rate: 50,
         last_run_timestamp: "2026-03-11T12:00:00+00:00",
       },
       tests: [
         {
-          test_id: "privacy%20tests%3A%3Adetect_email",
-          test_name: "detect_email",
+          test_id: "tests%2Fprivacy_tests.py%3A%3Atest_detect_email",
+          test_node_id: "tests/privacy_tests.py::test_detect_email",
+          test_name: "test_detect_email",
           category: "privacy tests",
           suite_name: "PII validation suite",
           status: "failed",
@@ -66,13 +58,14 @@ jest.mock("./useCompliancePageContext", () => ({
           failed_runs: 1,
           flake_rate: 1,
           flaky: true,
-          file_name: "tests/test_pii_validation.py",
+          file_path: "tests/privacy_tests.py",
           last_duration_ms: 8,
           last_run_timestamp: "2026-03-11T12:00:00+00:00",
         },
         {
-          test_id: "privacy%20tests%3A%3Adetect_phone",
-          test_name: "detect_phone",
+          test_id: "tests%2Fprivacy_tests.py%3A%3Atest_detect_phone",
+          test_node_id: "tests/privacy_tests.py::test_detect_phone",
+          test_name: "test_detect_phone",
           category: "privacy tests",
           suite_name: "PII validation suite",
           status: "passed",
@@ -81,15 +74,33 @@ jest.mock("./useCompliancePageContext", () => ({
           failed_runs: 0,
           flake_rate: 0,
           flaky: false,
-          file_name: "tests/test_pii_validation.py",
+          file_path: "tests/privacy_tests.py",
           last_duration_ms: 7,
           last_run_timestamp: "2026-03-11T11:00:00+00:00",
+        },
+        {
+          test_id: "tests%2Fprivacy_tests.py%3A%3Atest_detect_ssn",
+          test_node_id: "tests/privacy_tests.py::test_detect_ssn",
+          test_name: "test_detect_ssn",
+          category: "privacy tests",
+          suite_name: "PII validation suite",
+          status: "not_run",
+          pass_rate: 0,
+          total_runs: 0,
+          failed_runs: 0,
+          flake_rate: 0,
+          flaky: false,
+          file_path: "tests/privacy_tests.py",
+          last_duration_ms: null,
+          last_run_timestamp: null,
         },
       ],
     },
     selectedTestCase: {
-      test_id: "privacy%20tests%3A%3Adetect_email",
-      test_name: "detect_email",
+      test_id: "tests%2Fprivacy_tests.py%3A%3Atest_detect_email",
+      test_node_id: "tests/privacy_tests.py::test_detect_email",
+      test_name: "test_detect_email",
+      file_path: "tests/privacy_tests.py",
       category: "privacy tests",
       suite_name: "PII validation suite",
       status: "failed",
@@ -117,19 +128,9 @@ jest.mock("./useCompliancePageContext", () => ({
           duration_ms: 8,
           last_run_timestamp: "2026-03-11T12:00:00+00:00",
           environment: "synthetic_history",
+          file_path: "tests/privacy_tests.py",
           error_message: "Detector missed expected email classification.",
           confidence_score: 0.19,
-        },
-        {
-          run_id: 1,
-          result_id: 21,
-          suite_name: "PII validation suite",
-          status: "passed",
-          duration_ms: 10,
-          last_run_timestamp: "2026-03-10T12:00:00+00:00",
-          environment: "synthetic_history",
-          error_message: null,
-          confidence_score: 0.88,
         },
       ],
     },
@@ -143,35 +144,37 @@ beforeEach(() => {
   mockLoadTestCase.mockClear();
 });
 
-test("renders category rail, summary metrics, and selected test history", async () => {
+test("renders individual tests from the same file separately and shows node metadata", async () => {
   render(<ComplianceTestingPage />);
 
-  expect(screen.getByText("Test Suites")).toBeInTheDocument();
-  expect(screen.getByText("Total Tests")).toBeInTheDocument();
-  expect(screen.getByText("12")).toBeInTheDocument();
-  expect(screen.getByText("privacy tests")).toBeInTheDocument();
-  expect(screen.getByText("detect_email")).toBeInTheDocument();
-  expect(screen.getByText("Execution History")).toBeInTheDocument();
-  expect(screen.getByText("Detector missed expected email classification.")).toBeInTheDocument();
+  expect(screen.getByText("test_detect_email")).toBeInTheDocument();
+  expect(screen.getByText("test_detect_phone")).toBeInTheDocument();
+  expect(screen.getByText("test_detect_ssn")).toBeInTheDocument();
+  expect(screen.getAllByText("tests/privacy_tests.py").length).toBeGreaterThan(0);
+  expect(screen.getByText("Pytest Node ID")).toBeInTheDocument();
+  expect(screen.getByText("tests/privacy_tests.py::test_detect_email")).toBeInTheDocument();
 
   await waitFor(() => {
     expect(mockLoadTestCategory).toHaveBeenCalled();
   });
 });
 
-test("supports selecting a test and changing filters", async () => {
+test("supports selecting a single test case and filtering by search and file path", async () => {
   const user = userEvent.setup();
   render(<ComplianceTestingPage />);
 
-  await user.click(screen.getByText("detect_phone"));
-  expect(mockLoadTestCase).toHaveBeenCalledWith("privacy%20tests%3A%3Adetect_phone");
+  await user.click(screen.getByText("test_detect_phone"));
+  expect(mockLoadTestCase).toHaveBeenCalledWith("tests%2Fprivacy_tests.py%3A%3Atest_detect_phone");
 
   await user.type(screen.getByPlaceholderText("Search by name, description, or file"), "email");
+  await user.type(screen.getByPlaceholderText("Filter by tests/path.py"), "privacy_tests.py");
+
   await waitFor(() => {
     expect(mockLoadTestCategory).toHaveBeenLastCalledWith(
       "privacy tests",
       expect.objectContaining({
         search: "email",
+        file_path: "privacy_tests.py",
         sort: "last_run",
       }),
     );

--- a/frontend/src/pages/compliance/utils.js
+++ b/frontend/src/pages/compliance/utils.js
@@ -28,7 +28,7 @@ export function statusTone(status = "") {
   if (["completed", "approved", "published", "active", "passed", "stable", "improving"].includes(normalized)) {
     return "text-emerald-600";
   }
-  if (["pending", "investigating", "in_review", "flagged", "skipped"].includes(normalized)) {
+  if (["pending", "investigating", "in_review", "flagged", "skipped", "not_run"].includes(normalized)) {
     return "text-amber-600";
   }
   if (["flaky", "unstable", "running"].includes(normalized)) {
@@ -45,7 +45,7 @@ export function statusBadgeClass(status = "") {
   if (["completed", "approved", "published", "active", "passed", "stable", "improving"].includes(normalized)) {
     return "bg-emerald-500/15 text-emerald-300 border border-emerald-400/30";
   }
-  if (["pending", "investigating", "in_review", "flagged", "skipped"].includes(normalized)) {
+  if (["pending", "investigating", "in_review", "flagged", "skipped", "not_run"].includes(normalized)) {
     return "bg-amber-500/15 text-amber-200 border border-amber-400/30";
   }
   if (["flaky", "unstable", "running"].includes(normalized)) {

--- a/routers/compliance_router.py
+++ b/routers/compliance_router.py
@@ -57,6 +57,7 @@ from services.test_management_service import (
     get_test_management_dashboard,
     list_managed_tests,
 )
+from services.test_discovery_service import build_test_node_id, normalize_test_file_path, split_test_node_id
 from utils.api_errors import error_payload
 
 router = APIRouter(prefix="/compliance", tags=["Compliance Workspace"])
@@ -193,13 +194,16 @@ def _serialize_test_run(run: ComplianceTestRun) -> dict:
 
 
 def _serialize_test_case(case: ComplianceTestCaseResult, run: ComplianceTestRun | None = None) -> dict:
+    file_path = normalize_test_file_path(case.file_name)
     payload = {
         "id": case.id,
         "test_name": case.name,
+        "test_node_id": build_test_node_id(test_name=case.name, file_path=file_path, category=run.category if run is not None else None),
         "dataset_name": case.dataset_name,
         "status": case.status,
         "description": case.description,
-        "file_name": case.file_name,
+        "file_path": file_path,
+        "file_name": file_path,
         "expected_result": case.expected_result,
         "actual_result": case.actual_result,
         "confidence_score": float(case.confidence_score) if case.confidence_score is not None else None,
@@ -296,7 +300,9 @@ class TestRunCreateRequest(BaseModel):
 
 class TestResultCreateRequest(BaseModel):
     test_name: str
+    test_node_id: str | None = None
     dataset_name: str | None = None
+    file_path: str | None = None
     file_name: str | None = None
     description: str | None = None
     expected_result: str | None = None
@@ -1000,10 +1006,11 @@ def get_test_dashboard(current_employee: dict = Depends(require_compliance_works
 
 @router.get("/tests/inventory")
 def list_managed_test_inventory(
-    category: str | None = Query(default=None),
-    status: str | None = Query(default=None),
-    search: str | None = Query(default=None),
-    sort: str = Query(default="last_run"),
+    category: str | None = None,
+    status: str | None = None,
+    search: str | None = None,
+    file_path: str | None = None,
+    sort: str = "last_run",
     current_employee: dict = Depends(require_compliance_workspace_access),
     db: Session = Depends(get_db),
 ):
@@ -1013,6 +1020,7 @@ def list_managed_test_inventory(
         category=category,
         status=status,
         search=search,
+        file_path=file_path,
         sort=sort,
     )
 
@@ -1036,6 +1044,7 @@ def get_test_category_detail(category_name: str, current_employee: dict = Depend
             "passing": summary["passing"],
             "failing": summary["failing"],
             "skipped": summary["skipped"],
+            "not_run": summary["not_run"],
             "flaky": summary["flaky"],
             "pass_rate": summary["average_pass_rate"],
             "last_run_timestamp": latest_run_timestamp,
@@ -1082,11 +1091,27 @@ def get_test_case_detail(test_id: str, current_employee: dict = Depends(require_
 
 @router.get("/tests/cases/{test_id}/history")
 def get_test_case_history(test_id: str, current_employee: dict = Depends(require_compliance_workspace_access), db: Session = Depends(get_db)):
+    test_id_value = str(test_id)
+    if test_id_value.isdigit():
+        case = (
+            db.query(ComplianceTestCaseResult, ComplianceTestRun)
+            .join(ComplianceTestRun, ComplianceTestRun.id == ComplianceTestCaseResult.test_run_id)
+            .filter(ComplianceTestCaseResult.id == int(test_id_value), ComplianceTestRun.organization_id == current_employee["organization_id"])
+            .first()
+        )
+        if not case:
+            raise HTTPException(status_code=404, detail=error_payload(detail="Test case not found", error_code="not_found"))
+        result, run = case
+        payload = _serialize_test_case(result, run)
+        payload["test_node_id"] = build_test_node_id(test_name=result.name, file_path=result.file_name, category=run.category)
+        payload["output"] = payload.pop("output_summary")
+        payload["error_message"] = payload.pop("error_details")
+        return {"history": [payload]}
     try:
         history = get_managed_test_history(
             db,
             organization_id=current_employee["organization_id"],
-            test_id=test_id,
+            test_id=test_id_value,
         )
     except ValueError:
         raise HTTPException(status_code=404, detail=error_payload(detail="Test case not found", error_code="not_found"))
@@ -1123,16 +1148,17 @@ def create_test_result(
     if not run:
         raise HTTPException(status_code=404, detail=error_payload(detail="Test run not found", error_code="not_found"))
 
+    derived_file_path, derived_test_name = split_test_node_id(payload.test_node_id) if payload.test_node_id else (None, payload.test_name)
     result = record_test_result(
         db,
         test_run_id=run.id,
-        test_name=payload.test_name,
+        test_name=derived_test_name,
         dataset_name=payload.dataset_name or run.dataset_name,
         expected_result=payload.expected_result,
         actual_result=payload.actual_result,
         status=payload.status,
         confidence_score=float(payload.confidence_score) if payload.confidence_score is not None else None,
-        file_name=payload.file_name,
+        file_name=payload.file_path or derived_file_path or payload.file_name,
         description=payload.description,
         duration_ms=payload.duration_ms,
         output=payload.output,

--- a/services/compliance_service.py
+++ b/services/compliance_service.py
@@ -340,24 +340,24 @@ def ensure_test_runs(db: Session, organization_id: int) -> None:
         matching = [path for path in test_files if key in path.name.lower()]
         seed_cases = [
             (
-                f"{display_name} smoke test",
-                f"tests/test_{key}_smoke.py",
+                f"test_{key}_primary_path",
+                f"tests/test_{key}_suite.py",
                 f"Validates the primary {display_name.lower()} path.",
                 120,
                 "All assertions passed.",
                 None,
             ),
             (
-                f"{display_name} regression guard",
-                f"tests/test_{key}_regression.py",
+                f"test_{key}_regression_guard",
+                f"tests/test_{key}_suite.py",
                 f"Protects the key {display_name.lower()} regressions.",
                 240,
                 "Regression suite executed.",
                 "Expected status 200 but received 500.",
             ),
             (
-                f"{display_name} optional scenario",
-                f"tests/test_{key}_optional.py",
+                f"test_{key}_optional_scenario",
+                f"tests/test_{key}_suite.py",
                 f"Covers optional {display_name.lower()} behavior.",
                 0,
                 "Skipped pending environment prerequisites.",

--- a/services/test_discovery_service.py
+++ b/services/test_discovery_service.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+DEFAULT_TESTS_ROOT = Path("tests")
+
+CATEGORY_RULES = (
+    ("security", "security tests"),
+    ("privacy", "privacy tests"),
+    ("pii", "privacy tests"),
+    ("auth", "security tests"),
+    ("ui", "UI tests"),
+    ("frontend", "UI tests"),
+    ("integration", "integration tests"),
+    ("api", "API tests"),
+    ("router", "API tests"),
+)
+
+
+def normalize_test_file_path(file_path: str | None) -> str | None:
+    if not file_path:
+        return None
+    return str(Path(file_path).as_posix())
+
+
+def build_test_node_id(*, test_name: str, file_path: str | None = None, category: str | None = None) -> str:
+    normalized_file_path = normalize_test_file_path(file_path)
+    if normalized_file_path:
+        return f"{normalized_file_path}::{test_name}"
+    if category:
+        return f"{category}::{test_name}"
+    return test_name
+
+
+def split_test_node_id(node_id: str | None) -> tuple[str | None, str]:
+    if not node_id:
+        return None, ""
+    if ".py::" in node_id:
+        file_path, test_name = node_id.split(".py::", 1)
+        return f"{file_path}.py", test_name
+    if "::" not in node_id:
+        return None, node_id
+    file_path, test_name = node_id.rsplit("::", 1)
+    return file_path, test_name
+
+
+def infer_test_category(file_path: str | None, test_name: str | None = None) -> str:
+    haystack = " ".join(part for part in [file_path or "", test_name or ""]).lower()
+    for needle, category in CATEGORY_RULES:
+        if needle in haystack:
+            return category
+    return "integration tests"
+
+
+def _iter_discovered_tests(tree: ast.AST, *, file_path: str) -> list[dict[str, str | None]]:
+    discovered: list[dict[str, str | None]] = []
+
+    def visit_class(node: ast.ClassDef, prefix: str | None = None) -> None:
+        class_prefix = node.name if prefix is None else f"{prefix}::{node.name}"
+        for child in node.body:
+            if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)) and child.name.startswith("test_"):
+                display_name = f"{class_prefix}::{child.name}"
+                discovered.append(
+                    {
+                        "test_name": display_name,
+                        "file_path": file_path,
+                        "node_id": build_test_node_id(test_name=display_name, file_path=file_path),
+                        "description": ast.get_docstring(child),
+                        "category": infer_test_category(file_path, display_name),
+                    }
+                )
+            elif isinstance(child, ast.ClassDef) and child.name.startswith("Test"):
+                visit_class(child, class_prefix)
+
+    for node in tree.body if isinstance(tree, ast.Module) else []:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name.startswith("test_"):
+            discovered.append(
+                {
+                    "test_name": node.name,
+                    "file_path": file_path,
+                    "node_id": build_test_node_id(test_name=node.name, file_path=file_path),
+                    "description": ast.get_docstring(node),
+                    "category": infer_test_category(file_path, node.name),
+                }
+            )
+        elif isinstance(node, ast.ClassDef) and node.name.startswith("Test"):
+            visit_class(node)
+    return discovered
+
+
+def discover_pytest_cases(tests_root: str | Path = DEFAULT_TESTS_ROOT) -> list[dict[str, str | None]]:
+    root = Path(tests_root)
+    if not root.exists():
+        return []
+
+    discovered: list[dict[str, str | None]] = []
+    for file_path in sorted(root.rglob("test_*.py")):
+        if file_path.is_absolute():
+            try:
+                relative_path = str(file_path.relative_to(root.parent).as_posix())
+            except ValueError:
+                relative_path = str(file_path.as_posix())
+        else:
+            relative_path = str(file_path.as_posix())
+        try:
+            tree = ast.parse(file_path.read_text(encoding="utf-8"))
+        except (OSError, SyntaxError, UnicodeDecodeError):
+            continue
+        discovered.extend(_iter_discovered_tests(tree, file_path=relative_path))
+    return discovered

--- a/services/test_management_service.py
+++ b/services/test_management_service.py
@@ -9,6 +9,13 @@ from sqlalchemy.orm import Session
 
 from database.models.compliance_test_case_result import ComplianceTestCaseResult
 from database.models.compliance_test_run import ComplianceTestRun
+from services.test_discovery_service import (
+    build_test_node_id,
+    discover_pytest_cases,
+    infer_test_category,
+    normalize_test_file_path,
+    split_test_node_id,
+)
 
 CATEGORY_DESCRIPTIONS = {
     "API tests": "Contract, routing, and backend integration checks.",
@@ -27,16 +34,13 @@ SORT_KEYS = {
 }
 
 
-def encode_test_id(*, category: str, test_name: str) -> str:
-    return quote(f"{category}::{test_name}", safe="")
+def encode_test_id(*, node_id: str | None = None, category: str | None = None, test_name: str, file_path: str | None = None) -> str:
+    canonical_node_id = node_id or build_test_node_id(test_name=test_name, file_path=file_path, category=category)
+    return quote(canonical_node_id, safe="")
 
 
-def decode_test_id(test_id: str) -> tuple[str, str]:
-    decoded = unquote(test_id)
-    if "::" not in decoded:
-        raise ValueError("Invalid test id")
-    category, test_name = decoded.split("::", 1)
-    return category, test_name
+def decode_test_id(test_id: str) -> str:
+    return unquote(test_id)
 
 
 def _status_rank(status: str) -> int:
@@ -68,11 +72,15 @@ def _coerce_datetime(value: datetime | None) -> datetime | None:
 def _history_row(case: ComplianceTestCaseResult, run: ComplianceTestRun) -> dict[str, object]:
     finished_at = _coerce_datetime(case.last_run_at) or _coerce_datetime(run.run_at)
     started_at = None
+    file_path = normalize_test_file_path(case.file_name)
+    test_node_id = build_test_node_id(test_name=case.name, file_path=file_path, category=run.category)
     if finished_at is not None and case.duration_ms is not None:
         started_at = finished_at - timedelta(milliseconds=max(case.duration_ms, 0))
     return {
         "result_id": case.id,
         "run_id": run.id,
+        "test_node_id": test_node_id,
+        "test_name": case.name,
         "suite_name": run.suite_name,
         "dataset_name": case.dataset_name or run.dataset_name,
         "category": run.category,
@@ -87,7 +95,8 @@ def _history_row(case: ComplianceTestCaseResult, run: ComplianceTestRun) -> dict
         "output": case.output,
         "error_message": case.error_message,
         "description": case.description,
-        "file_name": case.file_name,
+        "file_path": file_path,
+        "file_name": file_path,
         "environment": case.dataset_name or run.dataset_name or "default",
         "build_version": None,
     }
@@ -123,7 +132,7 @@ def _compute_trend(history: list[dict[str, object]]) -> str:
     return "stable"
 
 
-def _summarize_test_history(category: str, test_name: str, rows: list[tuple[ComplianceTestCaseResult, ComplianceTestRun]]) -> dict[str, object]:
+def _summarize_test_history(node_id: str, rows: list[tuple[ComplianceTestCaseResult, ComplianceTestRun]]) -> dict[str, object]:
     ordered_rows = sorted(
         rows,
         key=lambda row: (_coerce_datetime(row[0].last_run_at) or _coerce_datetime(row[1].run_at) or datetime.min.replace(tzinfo=timezone.utc)),
@@ -131,6 +140,7 @@ def _summarize_test_history(category: str, test_name: str, rows: list[tuple[Comp
     )
     history = [_history_row(case, run) for case, run in ordered_rows]
     latest_case, latest_run = ordered_rows[0]
+    file_path, _ = split_test_node_id(node_id)
     statuses = [item["status"] for item in history]
     passed_runs = statuses.count("passed")
     failed_runs = statuses.count("failed")
@@ -147,13 +157,15 @@ def _summarize_test_history(category: str, test_name: str, rows: list[tuple[Comp
     flaky = passed_runs > 0 and failed_runs > 0
 
     return {
-        "test_id": encode_test_id(category=category, test_name=test_name),
-        "test_name": test_name,
-        "category": category,
+        "test_id": encode_test_id(node_id=node_id, test_name=latest_case.name),
+        "test_node_id": node_id,
+        "test_name": latest_case.name,
+        "category": latest_run.category or infer_test_category(file_path, latest_case.name),
         "suite_name": latest_run.suite_name,
         "status": _normalize_status(latest_case.status),
         "description": latest_case.description,
-        "file_name": latest_case.file_name,
+        "file_path": file_path or normalize_test_file_path(latest_case.file_name),
+        "file_name": file_path or normalize_test_file_path(latest_case.file_name),
         "expected_result": latest_case.expected_result,
         "actual_result": latest_case.actual_result,
         "confidence_score": float(latest_case.confidence_score) if latest_case.confidence_score is not None else None,
@@ -189,16 +201,28 @@ def _query_test_rows(db: Session, *, organization_id: int):
 
 
 def _build_test_inventory(db: Session, *, organization_id: int) -> list[dict[str, object]]:
-    grouped: dict[tuple[str, str], list[tuple[ComplianceTestCaseResult, ComplianceTestRun]]] = defaultdict(list)
+    grouped: dict[str, list[tuple[ComplianceTestCaseResult, ComplianceTestRun]]] = defaultdict(list)
     for case, run in _query_test_rows(db, organization_id=organization_id):
-        grouped[(run.category, case.name)].append((case, run))
-    inventory = [
-        _summarize_test_history(category, test_name, rows)
-        for (category, test_name), rows in grouped.items()
-    ]
+        grouped[build_test_node_id(test_name=case.name, file_path=case.file_name, category=run.category)].append((case, run))
+    inventory_by_node_id = {
+        node_id: _summarize_test_history(node_id, rows)
+        for node_id, rows in grouped.items()
+    }
+    discovered_by_node_id = {str(item["node_id"]): item for item in discover_pytest_cases()}
+    for node_id, current in inventory_by_node_id.items():
+        discovered_test = discovered_by_node_id.get(node_id)
+        if not discovered_test:
+            continue
+        if not current.get("description") and discovered_test.get("description"):
+            current["description"] = discovered_test["description"]
+        current["file_path"] = discovered_test["file_path"]
+        current["file_name"] = discovered_test["file_path"]
+        if current.get("category") in {None, "", "integration tests"}:
+            current["category"] = discovered_test["category"]
+    inventory = list(inventory_by_node_id.values())
     return sorted(
         inventory,
-        key=lambda item: (_status_rank(str(item["status"])), item["last_run_timestamp"] or "", item["test_name"].lower()),
+        key=lambda item: (_status_rank(str(item["status"])), item["last_run_timestamp"] or "", str(item["file_path"] or ""), item["test_name"].lower()),
         reverse=True,
     )
 
@@ -208,9 +232,11 @@ def _category_rollup(category: str, tests: list[dict[str, object]]) -> dict[str,
     failing = sum(1 for item in tests if item["status"] == "failed")
     skipped = sum(1 for item in tests if item["status"] == "skipped")
     flaky = sum(1 for item in tests if item["flaky"])
+    not_run = sum(1 for item in tests if item["status"] == "not_run")
     last_run = max((item["last_run_timestamp"] for item in tests if item["last_run_timestamp"]), default=None)
-    average_pass_rate = round(mean([item["pass_rate"] for item in tests]), 2) if tests else 0.0
-    latest_status = "failed" if failing else "passed" if passing else "skipped" if skipped else "unknown"
+    tests_with_runs = [item["pass_rate"] for item in tests if item["total_runs"]]
+    average_pass_rate = round(mean(tests_with_runs), 2) if tests_with_runs else 0.0
+    latest_status = "failed" if failing else "passed" if passing else "skipped" if skipped else "not_run" if not_run else "unknown"
     return {
         "category": category,
         "description": CATEGORY_DESCRIPTIONS.get(category, "Automated compliance validation coverage."),
@@ -218,6 +244,7 @@ def _category_rollup(category: str, tests: list[dict[str, object]]) -> dict[str,
         "passing": passing,
         "failing": failing,
         "skipped": skipped,
+        "not_run": not_run,
         "flaky": flaky,
         "average_pass_rate": average_pass_rate,
         "status": latest_status,
@@ -238,7 +265,9 @@ def get_test_management_dashboard(db: Session, *, organization_id: int) -> dict[
     passing_tests = sum(1 for item in inventory if item["status"] == "passed")
     failing_tests = sum(1 for item in inventory if item["status"] == "failed")
     flaky_tests = sum(1 for item in inventory if item["flaky"])
-    average_pass_rate = round(mean([item["pass_rate"] for item in inventory]), 2) if inventory else 0.0
+    not_run_tests = sum(1 for item in inventory if item["status"] == "not_run")
+    tests_with_runs = [item["pass_rate"] for item in inventory if item["total_runs"]]
+    average_pass_rate = round(mean(tests_with_runs), 2) if tests_with_runs else 0.0
     recent_cutoff = datetime.now(timezone.utc) - timedelta(days=7)
     total_executions_last_7_days = sum(
         1
@@ -253,6 +282,7 @@ def get_test_management_dashboard(db: Session, *, organization_id: int) -> dict[
             "passing_tests": passing_tests,
             "failing_tests": failing_tests,
             "flaky_tests": flaky_tests,
+            "not_run_tests": not_run_tests,
             "average_pass_rate": average_pass_rate,
             "total_executions_last_7_days": total_executions_last_7_days,
         },
@@ -267,6 +297,7 @@ def list_managed_tests(
     category: str | None = None,
     status: str | None = None,
     search: str | None = None,
+    file_path: str | None = None,
     sort: str = "last_run",
 ) -> dict[str, object]:
     inventory = _build_test_inventory(db, organization_id=organization_id)
@@ -285,8 +316,11 @@ def list_managed_tests(
             item for item in filtered
             if needle in item["test_name"].lower()
             or needle in str(item.get("description") or "").lower()
-            or needle in str(item.get("file_name") or "").lower()
+            or needle in str(item.get("file_path") or "").lower()
         ]
+    if file_path:
+        normalized_path = file_path.strip().lower()
+        filtered = [item for item in filtered if normalized_path in str(item.get("file_path") or "").lower()]
 
     sort_key = SORT_KEYS.get(sort, SORT_KEYS["last_run"])
     reverse = sort != "name"
@@ -297,17 +331,18 @@ def list_managed_tests(
         "passing": sum(1 for item in filtered if item["status"] == "passed"),
         "failing": sum(1 for item in filtered if item["status"] == "failed"),
         "skipped": sum(1 for item in filtered if item["status"] == "skipped"),
+        "not_run": sum(1 for item in filtered if item["status"] == "not_run"),
         "flaky": sum(1 for item in filtered if item["flaky"]),
-        "average_pass_rate": round(mean([item["pass_rate"] for item in filtered]), 2) if filtered else 0.0,
+        "average_pass_rate": round(mean([item["pass_rate"] for item in filtered if item["total_runs"]]), 2) if any(item["total_runs"] for item in filtered) else 0.0,
     }
     return {"tests": filtered, "summary": summary}
 
 
 def get_managed_test_detail(db: Session, *, organization_id: int, test_id: str) -> dict[str, object]:
-    category, test_name = decode_test_id(test_id)
+    node_id = decode_test_id(test_id)
     inventory = _build_test_inventory(db, organization_id=organization_id)
     for item in inventory:
-        if item["category"] == category and item["test_name"] == test_name:
+        if item["test_node_id"] == node_id:
             return item
     raise ValueError("Test not found")
 

--- a/services/test_metrics_service.py
+++ b/services/test_metrics_service.py
@@ -8,6 +8,7 @@ from sqlalchemy.orm import Session
 
 from database.models.compliance_test_case_result import ComplianceTestCaseResult
 from database.models.compliance_test_run import ComplianceTestRun
+from services.test_discovery_service import split_test_node_id
 
 
 NON_PII_SENTINELS = {"", "NONE", "NON_PII", "NOT_PII", "NO_DETECTION", "NULL"}
@@ -54,22 +55,25 @@ def record_test_result(
     *,
     test_run_id: int,
     test_name: str,
+    test_node_id: str | None = None,
     dataset_name: str | None,
     expected_result: str | None,
     actual_result: str | None,
     status: str,
     confidence_score: float | None,
+    file_path: str | None = None,
     file_name: str | None = None,
     description: str | None = None,
     duration_ms: int | None = None,
     output: str | None = None,
     error_message: str | None = None,
 ) -> ComplianceTestCaseResult:
+    derived_file_path, derived_test_name = split_test_node_id(test_node_id) if test_node_id else (None, test_name)
     result = ComplianceTestCaseResult(
         test_run_id=test_run_id,
-        name=test_name,
+        name=derived_test_name,
         dataset_name=dataset_name,
-        file_name=file_name,
+        file_name=file_path or derived_file_path or file_name,
         description=description,
         expected_result=expected_result,
         actual_result=actual_result,
@@ -90,10 +94,12 @@ def track_test_execution(
     *,
     test_run_id: int,
     test_name: str,
+    test_node_id: str | None = None,
     dataset_name: str | None,
     expected_result: str | None,
     actual_result: str | None,
     confidence_score: float | None,
+    file_path: str | None = None,
     file_name: str | None = None,
     description: str | None = None,
     output: str | None = None,
@@ -107,11 +113,13 @@ def track_test_execution(
         db,
         test_run_id=test_run_id,
         test_name=test_name,
+        test_node_id=test_node_id,
         dataset_name=dataset_name,
         expected_result=normalized_expected or None,
         actual_result=normalized_actual or None,
         status=status,
         confidence_score=confidence_score,
+        file_path=file_path,
         file_name=file_name,
         description=description,
         duration_ms=round((perf_counter() - started_at) * 1000),

--- a/tests/test_compliance_workspace.py
+++ b/tests/test_compliance_workspace.py
@@ -476,6 +476,7 @@ def test_test_dashboard_inventory_and_history_support_management_views():
         first_run["id"],
         compliance_router.TestResultCreateRequest(
             test_name="detect_email",
+            file_path="tests/privacy_tests.py",
             dataset_name="synthetic_history",
             expected_result="PII_EMAIL",
             actual_result="PII_EMAIL",
@@ -491,6 +492,7 @@ def test_test_dashboard_inventory_and_history_support_management_views():
         second_run["id"],
         compliance_router.TestResultCreateRequest(
             test_name="detect_email",
+            file_path="tests/privacy_tests.py",
             dataset_name="synthetic_history",
             expected_result="PII_EMAIL",
             actual_result="NON_PII",
@@ -507,6 +509,7 @@ def test_test_dashboard_inventory_and_history_support_management_views():
         second_run["id"],
         compliance_router.TestResultCreateRequest(
             test_name="detect_phone",
+            file_path="tests/privacy_tests.py",
             dataset_name="synthetic_history",
             expected_result="PII_PHONE",
             actual_result="PII_PHONE",
@@ -528,7 +531,7 @@ def test_test_dashboard_inventory_and_history_support_management_views():
         current_employee=_employee_context(employee),
         db=session,
     )
-    test_id = encode_test_id(category="privacy tests", test_name="detect_email")
+    test_id = encode_test_id(test_name="detect_email", file_path="tests/privacy_tests.py")
     detail = compliance_router.get_test_case_detail(test_id, current_employee=_employee_context(employee), db=session)
     history = compliance_router.get_test_case_history(test_id, current_employee=_employee_context(employee), db=session)
 
@@ -540,8 +543,77 @@ def test_test_dashboard_inventory_and_history_support_management_views():
     assert inventory["tests"][0]["test_name"] == "detect_email"
     assert detail["trend"] in {"unstable", "degrading"}
     assert detail["total_runs"] == 2
+    assert detail["file_path"] == "tests/privacy_tests.py"
     assert len(history["history"]) == 2
     assert history["history"][0]["status"] in {"failed", "passed"}
+
+
+def test_inventory_renders_same_file_tests_and_same_name_different_files_separately():
+    session = _session()
+    _, _, employee = _seed_org(session)
+
+    run = compliance_router.create_test_run(
+        compliance_router.TestRunCreateRequest(
+            category="privacy tests",
+            suite_name="PII validation suite",
+            status="running",
+            dataset_name="synthetic_split_inventory",
+        ),
+        current_employee=_employee_context(employee),
+        db=session,
+    )
+
+    payloads = [
+        compliance_router.TestResultCreateRequest(
+            test_name="test_detect_email",
+            file_path="tests/privacy_tests.py",
+            dataset_name="synthetic_split_inventory",
+            expected_result="PII_EMAIL",
+            actual_result="PII_EMAIL",
+            status="passed",
+            confidence_score=0.91,
+        ),
+        compliance_router.TestResultCreateRequest(
+            test_name="test_detect_phone",
+            file_path="tests/privacy_tests.py",
+            dataset_name="synthetic_split_inventory",
+            expected_result="PII_PHONE",
+            actual_result="PII_PHONE",
+            status="passed",
+            confidence_score=0.84,
+        ),
+        compliance_router.TestResultCreateRequest(
+            test_name="test_detect_email",
+            file_path="tests/security_tests.py",
+            dataset_name="synthetic_split_inventory",
+            expected_result="PII_EMAIL",
+            actual_result="NON_PII",
+            status="failed",
+            confidence_score=0.14,
+            error_message="Security suite variant failed.",
+        ),
+    ]
+    for payload in payloads:
+        compliance_router.create_test_result(
+            run["id"],
+            payload,
+            current_employee=_employee_context(employee),
+            db=session,
+        )
+
+    inventory = compliance_router.list_managed_test_inventory(
+        category="privacy tests",
+        search="tests/",
+        sort="name",
+        current_employee=_employee_context(employee),
+        db=session,
+    )
+
+    test_node_ids = {item["test_node_id"] for item in inventory["tests"] if item["file_path"] in {"tests/privacy_tests.py", "tests/security_tests.py"}}
+    assert "tests/privacy_tests.py::test_detect_email" in test_node_ids
+    assert "tests/privacy_tests.py::test_detect_phone" in test_node_ids
+    assert "tests/security_tests.py::test_detect_email" in test_node_ids
+    assert len(test_node_ids) == 3
 
 
 def test_compliance_overview_returns_attention_data():

--- a/tests/test_test_discovery_service.py
+++ b/tests/test_test_discovery_service.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+
+from services.test_discovery_service import build_test_node_id, discover_pytest_cases, split_test_node_id
+
+
+def test_discover_pytest_cases_returns_individual_functions_and_methods():
+    test_file = Path("tests/test_generated_discovery_suite.py")
+    try:
+        test_file.write_text(
+            """
+def test_detect_email():
+    \"\"\"Email detection stays separate.\"\"\"
+    assert True
+
+def test_detect_phone():
+    assert True
+
+class TestRiskSignals:
+    def test_detect_ssn(self):
+        assert True
+""".strip(),
+            encoding="utf-8",
+        )
+
+        discovered = discover_pytest_cases("tests")
+        node_ids = {item["node_id"] for item in discovered}
+        assert "tests/test_generated_discovery_suite.py::test_detect_email" in node_ids
+        assert "tests/test_generated_discovery_suite.py::test_detect_phone" in node_ids
+        assert "tests/test_generated_discovery_suite.py::TestRiskSignals::test_detect_ssn" in node_ids
+    finally:
+        if test_file.exists():
+            test_file.unlink()
+
+
+def test_build_and_split_test_node_id_round_trip():
+    node_id = build_test_node_id(test_name="test_detect_email", file_path="tests/privacy_tests.py")
+    file_path, test_name = split_test_node_id(node_id)
+    assert node_id == "tests/privacy_tests.py::test_detect_email"
+    assert file_path == "tests/privacy_tests.py"
+    assert test_name == "test_detect_email"
+
+
+def test_split_test_node_id_preserves_class_method_names():
+    file_path, test_name = split_test_node_id("tests/privacy_tests.py::TestRiskSignals::test_detect_ssn")
+    assert file_path == "tests/privacy_tests.py"
+    assert test_name == "TestRiskSignals::test_detect_ssn"


### PR DESCRIPTION
Promote pytest-style test node IDs to the primary identity for compliance test inventory so tests in the same file render independently.

Add test discovery and per-test file-path aware aggregation, then update the Testing & Validation workspace to show node metadata, file-level filtering, and test-case-specific history instead of file-level grouping.